### PR TITLE
Add the function exchangeLabel to fast change the annotation labels with mouse's middle button

### DIFF
--- a/scripts_to_build/win_make_vc14_x64_to_edit.bat
+++ b/scripts_to_build/win_make_vc14_x64_to_edit.bat
@@ -3,7 +3,7 @@ cd build
 mkdir x64
 cd x64
 
-cmake -DQT5_DIR=/path/to/Qt/5.9.1/msvc2015_64/lib/cmake -DCMAKE_PREFIX_PATH=/path/to/OpenCV/build -G "Visual Studio 14 Win64" ../../..
+cmake -DQT5_DIR=D:/Qt/5.11.2/msvc2015_64/lib/cmake -DCMAKE_PREFIX_PATH=D:/lib/opencv/opencv343/build -G "Visual Studio 14 Win64" ../../..
 
 cmake --build . --config Release
 

--- a/scripts_to_build/win_make_vc14_x64_to_edit.bat
+++ b/scripts_to_build/win_make_vc14_x64_to_edit.bat
@@ -3,7 +3,7 @@ cd build
 mkdir x64
 cd x64
 
-cmake -DQT5_DIR=D:/Qt/5.11.2/msvc2015_64/lib/cmake -DCMAKE_PREFIX_PATH=D:/lib/opencv/opencv343/build -G "Visual Studio 14 Win64" ../../..
+cmake -DQT5_DIR=/path/to/Qt/5.9.1/msvc2015_64/lib/cmake -DCMAKE_PREFIX_PATH=/path/to/OpenCV/build -G "Visual Studio 14 Win64" ../../..
 
 cmake --build . --config Release
 

--- a/src/image_canvas.cpp
+++ b/src/image_canvas.cpp
@@ -190,6 +190,22 @@ void ImageCanvas::mouseReleaseEvent(QMouseEvent * e) {
 
 		refresh();
 	}
+
+	if (e->button() == Qt::MiddleButton)
+	{
+		int x, y;
+		if (_pen_size > 0) {
+			x = e->x() / _scale;
+			y = e->y() / _scale;
+		}
+		else {
+			x = (e->x() + 0.5) / _scale;
+			y = (e->y() + 0.5) / _scale;
+		}
+
+		_mask.exchangeLabel(x, y, _ui->id_labels, _color);
+		update();
+	}
 }
 
 void ImageCanvas::mousePressEvent(QMouseEvent * e) {

--- a/src/image_mask.cpp
+++ b/src/image_mask.cpp
@@ -41,3 +41,17 @@ void ImageMask::drawPixel(int x, int y, ColorMask cm) {
 void ImageMask::updateColor(const Id2Labels & labels) {
 	idToColor(id, labels, &color);
 }
+
+void ImageMask::exchangeLabel(int x, int y, const Id2Labels& id_labels, ColorMask cm) {
+
+	QColor current_id = id.pixelColor(QPoint(x, y));
+	if (current_id.red() == 0 || current_id.green() == 0 || current_id.blue() == 0)
+		return;
+
+	cv::Mat id_mat = qImage2Mat(id);
+	cv::floodFill(id_mat, cv::Point(x, y), cv::Scalar(cm.id.red(), cm.id.green(), cm.id.blue()), 0, cv::Scalar(0, 0, 0), cv::Scalar(0, 0, 0));
+
+	id = mat2QImage(id_mat);
+	color = idToColor(id, id_labels);
+
+}

--- a/src/image_mask.h
+++ b/src/image_mask.h
@@ -20,6 +20,7 @@ struct ImageMask {
 	void drawFillCircle(int x, int y, int pen_size, ColorMask cm);
 	void drawPixel(int x, int y, ColorMask cm);
 	void updateColor(const Id2Labels & labels);
+	void exchangeLabel(int x, int y, const Id2Labels & id_labels, ColorMask cm);
 };
 
 #endif


### PR DESCRIPTION
Hi,

I love to use this tool for my deep learning project. But sometimes semantic definitions are hard to define in once. It will be flexible to fast change some label by hand as the project going. So I wrote this function to fast change the existed label with mouse's middle button.

Hope you would like this additional function.

Thanks!