### PR TITLE
Label shortcuts for quicker annotations and different text colors (black/white only)

### DIFF
--- a/src/label_widget.cpp
+++ b/src/label_widget.cpp
@@ -19,7 +19,7 @@ void LabelWidget::setNewLabel(const LabelInfo &label) {
 
 	setText(text);
 	setAlignment(Qt::AlignHCenter);
-	setStyleSheet("QLabel { background-color : " + label.color.name() + "; color : " + invColor(_label.color).name() + ";  font: bold 14px; }");
+	setStyleSheet("QLabel { background-color : " + label.color.name() + "; color : " + readableColor(_label.color).name() + ";  font:  14px; }");
 }
 
 void LabelWidget::setSelected(bool s) {
@@ -40,4 +40,8 @@ void LabelWidget::paintEvent(QPaintEvent *event) {
 		p.drawRect(rect());
 		p.end();
 	}
+}
+
+QString LabelWidget::getName(){
+	return this->_label.name;
 }

--- a/src/label_widget.cpp
+++ b/src/label_widget.cpp
@@ -13,7 +13,11 @@ LabelWidget::LabelWidget(const LabelInfo &label, QWidget *parent , Qt::WindowFla
 
 void LabelWidget::setNewLabel(const LabelInfo &label) {
 	_label = label;
-	setText(label.name);
+	QString text = (label.shortcut) ?
+			label.name + " (" + label.shortcut->key().toString() + ")" :
+			label.name;
+
+	setText(text);
 	setAlignment(Qt::AlignHCenter);
 	setStyleSheet("QLabel { background-color : " + label.color.name() + "; color : " + invColor(_label.color).name() + ";  font: bold 14px; }");
 }

--- a/src/label_widget.h
+++ b/src/label_widget.h
@@ -18,6 +18,7 @@ public:
 	
 	void setNewLabel(const LabelInfo &label);
 	void setSelected(bool s);
+	QString getName();
 
 public : // override
 	void paintEvent(QPaintEvent *event) override;

--- a/src/labels.cpp
+++ b/src/labels.cpp
@@ -15,6 +15,7 @@ LabelInfo::LabelInfo() {
 	this->id_categorie = 0;
 	this->color = QColor(0, 0, 0);
 	item = NULL;
+	shortcut = nullptr;
 }
 
 LabelInfo::LabelInfo(QString name, QString categorie, int id, int id_categorie, QColor color) {
@@ -24,6 +25,7 @@ LabelInfo::LabelInfo(QString name, QString categorie, int id, int id_categorie, 
 	this->id_categorie = id_categorie;
 	this->color = color;
 	item = NULL;
+	shortcut = nullptr;
 }
 
 void LabelInfo::read(const QJsonObject &json) {

--- a/src/labels.h
+++ b/src/labels.h
@@ -3,6 +3,7 @@
 
 #include <QListWidgetItem>
 #include <QJsonObject>
+#include <QtWidgets/QShortcut>
 
 class LabelInfo  {
 public:
@@ -12,6 +13,7 @@ public:
 	int     id_categorie ;
 	QColor  color        ;
 	QListWidgetItem *item;
+	QShortcut *shortcut  ;
 	LabelInfo();
 	LabelInfo(QString name, QString categorie, int id, int id_categorie, QColor color);
 	void read(const QJsonObject &json);

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -177,7 +177,7 @@ void MainWindow::changeLabel(QListWidgetItem* current, QListWidgetItem* previous
 	label->setSelected(true);
 
 	QString str;
-	QString key = label->text();
+	QString key = label->getName();
 	QTextStream sstr(&str);
 	sstr <<"label=["<< key <<"] id=[" << labels[key].id << "] categorie=[" << labels[key].categorie << "] color=[" << labels[key].color.name() << "]" ;
 	statusBar()->showMessage(str);

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -118,7 +118,27 @@ void MainWindow::loadConfigLabels() {
 		item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 		list_label->addItem(item);
 		list_label->setItemWidget(item, label_widget);
-		labels[it.key()].item = item;
+
+		auto& ref = labels[it.key()];
+		ref.item = item;
+
+		int id = list_label->row(item);
+		const QString shortcut_key = (id < 9)  ? QString("Ctrl+%1").arg(id + 1) :
+                                            (id < 19) ? QString("Alt+%1").arg(id - 10 + 1)  :
+                                            (id < 29) ? QString("Ctrl+Alt+%1").arg(id - 20 + 1) :
+                                            (id < 39) ? QString("Ctrl+Shift+Alt+%1").arg(id - 30 + 1) :
+                                            QString();
+
+		if(id < 39) {
+			QShortcut *shortcut = new QShortcut(QKeySequence(shortcut_key), this);
+			ref.shortcut = shortcut;
+
+			QString text = label.name + " (" + ref.shortcut->key().toString() + ")";
+			label_widget->setText(text);
+
+			connect(shortcut, &QShortcut::activated, this, [=]{onLabelShortcut(id);});
+		}
+
 	}
 	id_labels = getId2Label(labels);
 }
@@ -421,3 +441,7 @@ void MainWindow::swapView() {
     ic->update();
 }
 
+void MainWindow::onLabelShortcut(int row) {
+	if(list_label->isEnabled())
+		list_label->setCurrentRow(row);
+	}

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -81,6 +81,7 @@ public slots:
     void clearMask();
 	void updateConnect(int index);
     void treeWidgetClicked();
+    void onLabelShortcut(int row);
 };
 
 #endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -47,6 +47,17 @@ void idToColor(const QImage &image_id, const Id2Labels& id_label, QImage *result
 	}
 }
 
+QColor readableColor(const QColor & color)
+{
+	int r, g, b;
+	color.getRgb(&r, &g, &b);
+
+	if ((r*0.299 + g*0.587 + b*0.114) > 150)
+		return QColor(0, 0, 0);
+
+	return QColor(255, 255, 255);
+
+}
 QColor invColor(const QColor& color) {
 	int h, s, v;
 	color.getHsv(&h, &s, &v);

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,6 +13,7 @@ QImage idToColor(const QImage &image_id, const Id2Labels& id_label);
 void idToColor(const QImage &image_id, const Id2Labels& id_label, QImage *result);
 inline bool operator<(const QColor & a, const QColor & b) { return a.rgb() < b.rgb(); }
 QColor invColor(const QColor & color);
+QColor readableColor(const QColor & color);
 QVector<QColor> colorMap(int size);
 cv::Mat convertMat32StoRGBC3(const cv::Mat &mat);
 QImage watershed(const QImage& qimage, const QImage & qmarkers_mask);


### PR DESCRIPTION
This tool is great (really!!) but I feel it takes longer than I wanted to hover the mouse over to the left pane. This slightly time-consuming task adds up quickly when annotating hundreds of images. A quick change lets us change the current item by pressing key combinations, such as Ctrl+num or Ctrl+Alt+num or Ctrl+Shift+Alt+num. 

Also, I found the text on the left pane hard to read with all these colors and with a bold font, so I changed that to plain white (on dark backgrounds) or black (on light backgrounds) and removed bold. IMO that looks easier to read.