### PR TITLE
Delete shortcuts so it works when we load a new config. Add shortcut for watershed

### DIFF
--- a/src/labels.cpp
+++ b/src/labels.cpp
@@ -28,6 +28,12 @@ LabelInfo::LabelInfo(QString name, QString categorie, int id, int id_categorie, 
 	shortcut = nullptr;
 }
 
+LabelInfo::~LabelInfo() {
+
+    delete item;
+    delete shortcut;
+}
+
 void LabelInfo::read(const QJsonObject &json) {
 	id = json["id"].toInt();
 	name = json["name"].toString();

--- a/src/labels.h
+++ b/src/labels.h
@@ -18,6 +18,8 @@ public:
 	LabelInfo(QString name, QString categorie, int id, int id_categorie, QColor color);
 	void read(const QJsonObject &json);
 	void write(QJsonObject &json) const;
+
+    ~LabelInfo();
 };
 
 class Name2Labels : public QMap<QString, LabelInfo> {

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -44,6 +44,11 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 	undo_action->setEnabled(false);
 	redo_action->setEnabled(false);
 
+	watershed_shortcut = new QShortcut(QKeySequence("Ctrl+F"), this);
+	connect(watershed_shortcut, SIGNAL(activated()), this, SLOT(runWatershed()));
+	button_watershed->setText(button_watershed->text() +
+	QString("(%1)").arg(watershed_shortcut->key().toString()));
+
 	menuFile->addAction(save_action);
     menuEdit->addAction(close_tab_action);
 	menuEdit->addAction(undo_action);

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -54,6 +54,8 @@ public:
     QAction        * swap_action;
 	QAction        * redo_action  ;
 	QString          curr_open_dir;
+	QShortcut        * watershed_shortcut;
+
 public:
 	QString currentDir() const;
 	QString currentFile() const;


### PR DESCRIPTION
Unless we hook a delete call for the shortcut when LabelInfo objects go out of scope, we will not be able to add a new shortcut for the same QKeySequence.This is problematic in the event we want to load another config file: shortcuts simply will not work in this case.  This quick change fixes this.

I also took the opportunity to delete 'item', since it is a pointer type acquired with new that is not destroyed anywhere (I guessed by briefly looking at the source code, since I am not that familiar with Qt)

Lastly, I added a shortcut for the run watershed button while I was at it.