### PR TITLE
making pen_size, scale and mask alpha persistent across tabs

### DIFF
--- a/src/image_canvas.cpp
+++ b/src/image_canvas.cpp
@@ -7,14 +7,14 @@
 
 ImageCanvas::ImageCanvas(MainWindow *ui) :
     QLabel() ,
-	_ui(ui),
-	_alpha(0.5),
-	_pen_size(30) {
+	_ui(ui){
 
     _scroll_parent = new QScrollArea(ui);
     setParent(_scroll_parent);
 	resize(800,600);
-	_scale = 1.0;
+	_scale = _ui->spinbox_scale->value();
+	_alpha = _ui->spinbox_alpha->value();
+	_pen_size = _ui->spinbox_pen_size->value();
 	_initPixmap();
 	setScaledContents(true);
 	setMouseTracking(true);


### PR DESCRIPTION
I believe the image scale, pen size and mask alpha should persist across tabs so I made some minor tweaks to avoid having to repeatedly adjust these settings after opening every image. 