### PR TITLE
User Settings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,9 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    app.setOrganizationName("pixelannotationtool_org");
+    app.setOrganizationDomain("pixelannotationtool_domain");
+    app.setApplicationName("PixelAnnotationTool");
 
 	MainWindow win;
 	win.show();

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -15,6 +15,7 @@
 #include <QColorDialog>
 #include <QTextStream>
 #include <QMimeData>
+#include <QSettings>
 #include "pixel_annotation_tool_version.h"
 
 #include "about_dialog.h"
@@ -88,6 +89,35 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
     list_label->setEnabled(false);
 
     setAcceptDrops(true);
+    readSettings();
+}
+
+void MainWindow::writeSettings()
+{
+    QSettings settings(QSettings::UserScope);
+
+    settings.setValue("window/size", size());
+    settings.setValue("window/pos", pos());
+    settings.setValue("pen_size", spinbox_pen_size->value());
+    settings.setValue("alpha", spinbox_alpha->value());
+    settings.setValue("scale", spinbox_scale->value());
+}
+
+void MainWindow::readSettings()
+{
+    QSettings settings(QSettings::UserScope);
+
+    resize(settings.value("window/size", QSize(1511, 967)).toSize());
+    move(settings.value("window/pos", QPoint(0, 0)).toPoint());
+    spinbox_pen_size->setValue(settings.value("pen_size", QVariant(30)).toInt());
+    spinbox_alpha->setValue(settings.value("alpha", QVariant(0.4)).toDouble());
+    spinbox_scale->setValue(settings.value("scale", QVariant(1.0)).toDouble());
+}
+
+void MainWindow::closeEvent(QCloseEvent *event)
+{
+    writeSettings();
+    event->accept();
 }
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *e) {

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -94,7 +94,7 @@ MainWindow::MainWindow(QWidget *parent, Qt::WindowFlags flags)
 
 void MainWindow::writeSettings()
 {
-    QSettings settings(QSettings::UserScope);
+    QSettings settings;
 
     settings.setValue("window/size", size());
     settings.setValue("window/pos", pos());
@@ -105,7 +105,7 @@ void MainWindow::writeSettings()
 
 void MainWindow::readSettings()
 {
-    QSettings settings(QSettings::UserScope);
+    QSettings settings;
 
     resize(settings.value("window/size", QSize(1511, 967)).toSize());
     move(settings.value("window/pos", QPoint(0, 0)).toPoint());

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -32,6 +32,8 @@ public:
 
 private:
 
+    void writeSettings();
+    void readSettings();
 	void loadConfigLabels();
     void openDirectory();
     QString stringForShortCut(int id) const;
@@ -71,6 +73,9 @@ public:
     void setStarAtNameOfTab(bool star);
     void dragEnterEvent(QDragEnterEvent *e) override;
     void dropEvent(QDropEvent *e) override;
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
 
 public slots:
 


### PR DESCRIPTION
This PR includes a small change for having user settings persistent over application restarts. 
It saves in user Scope position of window, size of window and the alpha, scale and pen_size. 