### PR TITLE
Continuous brush stroke

### DIFF
--- a/src/image_canvas.cpp
+++ b/src/image_canvas.cpp
@@ -152,8 +152,8 @@ void ImageCanvas::mouseMoveEvent(QMouseEvent * e) {
         QPoint cur_point = _get_pen_pose(e);
         _mask.drawLine(_prev_point, cur_point, _pen_size, _color);
         _prev_point = cur_point;
-        update();
     }
+    update();
 }
 
 void ImageCanvas::setSizePen(int pen_size) {

--- a/src/image_canvas.cpp
+++ b/src/image_canvas.cpp
@@ -138,12 +138,22 @@ void ImageCanvas::paintEvent(QPaintEvent *event) {
 	}
 }
 
+QPoint ImageCanvas::_get_pen_pose(QMouseEvent * e) {
+    int x = e->x() / _scale;
+    int y = e->y() / _scale;
+    return QPoint(x,y);
+}
+
 void ImageCanvas::mouseMoveEvent(QMouseEvent * e) {
 	_mouse_pos.setX(e->x());
 	_mouse_pos.setY(e->y());
 
-	if (_button_is_pressed) 
-		_drawFillCircle(e);
+    if (_button_is_pressed) {
+        QPoint cur_point = _get_pen_pose(e);
+        _mask.drawLine(_prev_point, cur_point, _pen_size, _color);
+        _prev_point = cur_point;
+        update();
+    }
 
 	update();
 }
@@ -151,7 +161,6 @@ void ImageCanvas::mouseMoveEvent(QMouseEvent * e) {
 void ImageCanvas::setSizePen(int pen_size) {
 	_pen_size = pen_size;
 }
-
 
 void ImageCanvas::mouseReleaseEvent(QMouseEvent * e) {
 	if(e->button() == Qt::LeftButton) {
@@ -212,23 +221,12 @@ void ImageCanvas::mouseReleaseEvent(QMouseEvent * e) {
 
 void ImageCanvas::mousePressEvent(QMouseEvent * e) {
 	setFocus();
-	if (e->button() == Qt::LeftButton) {
+    if (e->button() == Qt::LeftButton) {
+        _prev_point = _get_pen_pose(e);
 		_button_is_pressed = true;
-		_drawFillCircle(e);
+        _mask.drawFillCircle(_get_pen_pose(e), _pen_size, _color);
+        update();
 	}
-}
-
-void ImageCanvas::_drawFillCircle(QMouseEvent * e) {
-	if (_pen_size > 0) {
-		int x = e->x() / _scale - _pen_size / 2;
-		int y = e->y() / _scale - _pen_size / 2;
-		_mask.drawFillCircle(x, y, _pen_size, _color);
-	} else {
-		int x = (e->x()+0.5) / _scale ;
-		int y = (e->y()+0.5) / _scale ;
-		_mask.drawPixel(x, y, _color);
-	}
-	update();
 }
 
 void ImageCanvas::clearMask() {

--- a/src/image_canvas.cpp
+++ b/src/image_canvas.cpp
@@ -154,8 +154,6 @@ void ImageCanvas::mouseMoveEvent(QMouseEvent * e) {
         _prev_point = cur_point;
         update();
     }
-
-	update();
 }
 
 void ImageCanvas::setSizePen(int pen_size) {

--- a/src/image_canvas.h
+++ b/src/image_canvas.h
@@ -52,8 +52,8 @@ public slots :
 private:
 	MainWindow *_ui;
 	
-	void _initPixmap();
-	void _drawFillCircle(QMouseEvent * e);
+    void _initPixmap();
+    QPoint _get_pen_pose(QMouseEvent * e);
 
 	QScrollArea     *_scroll_parent    ;
 	double           _scale            ;
@@ -71,7 +71,7 @@ private:
 	ColorMask        _color            ;
 	int              _pen_size         ;
 	bool             _button_is_pressed;
-
+    QPoint          _prev_point        ;
 };
 
 

--- a/src/image_mask.cpp
+++ b/src/image_mask.cpp
@@ -15,29 +15,45 @@ ImageMask::ImageMask(QSize s) {
 	color.fill(QColor(0, 0, 0));
 }
 
-void ImageMask::drawFillCircle(int x, int y, int pen_size, ColorMask cm) {
-	QPen pen(QBrush(cm.id), 1.0);
+void ImageMask::drawLine(QPoint p1, QPoint p2, int pen_size, ColorMask cm) {
 	QPainter painter_id(&id);
-	painter_id.setRenderHint(QPainter::Antialiasing, false);
-	painter_id.setPen(pen);
-	painter_id.setBrush(QBrush(cm.id));
-	painter_id.drawEllipse(x, y, pen_size, pen_size);
+    painter_id.setRenderHint(QPainter::Antialiasing, false);
+    painter_id.setPen(QPen(cm.id, pen_size, Qt::SolidLine, Qt::RoundCap,
+                        Qt::RoundJoin));
+    painter_id.drawLine(p1, p2);
 	painter_id.end();
 
-	QPainter painter_color(&color);
-	QPen pen_color(QBrush(cm.color), 1.0);
-	painter_color.setRenderHint(QPainter::Antialiasing, false);
-	painter_color.setPen(pen_color);
-	painter_color.setBrush(QBrush(cm.color));
-	painter_color.drawEllipse(x, y, pen_size, pen_size);
-	painter_color.end();
+    QPainter painter_color(&color);
+    painter_color.setRenderHint(QPainter::Antialiasing, false);
+    painter_color.setPen(QPen(cm.color, pen_size, Qt::SolidLine, Qt::RoundCap,
+                        Qt::RoundJoin));
+    painter_color.drawLine(p1, p2);
+    painter_color.end();
 }
+void ImageMask::drawFillCircle(QPoint point, int pen_size, ColorMask cm) {
+    if(pen_size<=1) {
+        id.setPixelColor(point, cm.id);
+        color.setPixelColor(point, cm.color);
+    }
+    else {
+        pen_size = (pen_size-1)/2;
+        QPen pen(QBrush(cm.id), 1.0);
+        QPainter painter_id(&id);
+        painter_id.setRenderHint(QPainter::Antialiasing, false);
+        painter_id.setPen(pen);
+        painter_id.setBrush(QBrush(cm.id));
+        painter_id.drawEllipse(point, pen_size, pen_size);
+        painter_id.end();
 
-void ImageMask::drawPixel(int x, int y, ColorMask cm) {
-	id.setPixelColor(x, y, cm.id);
-	color.setPixelColor(x, y, cm.color);
+        QPainter painter_color(&color);
+        QPen pen_color(QBrush(cm.color), 1.0);
+        painter_color.setRenderHint(QPainter::Antialiasing, false);
+        painter_color.setPen(pen_color);
+        painter_color.setBrush(QBrush(cm.color));
+        painter_color.drawEllipse(point, pen_size, pen_size);
+        painter_color.end();
+    }
 }
-
 void ImageMask::updateColor(const Id2Labels & labels) {
 	idToColor(id, labels, &color);
 }

--- a/src/image_mask.h
+++ b/src/image_mask.h
@@ -17,8 +17,8 @@ struct ImageMask {
 	ImageMask(const QString &file, Id2Labels id_labels);
 	ImageMask(QSize s);
 
-	void drawFillCircle(int x, int y, int pen_size, ColorMask cm);
-	void drawPixel(int x, int y, ColorMask cm);
+    void drawLine(QPoint p1, QPoint p2, int pen_size, ColorMask cm);
+    void drawFillCircle(QPoint point, int pen_size, ColorMask cm);
 	void updateColor(const Id2Labels & labels);
 	void exchangeLabel(int x, int y, const Id2Labels & id_labels, ColorMask cm);
 };


### PR DESCRIPTION
Made brush stroke continuous rather than dotted.

This was done as I want to try weighting a user's manual input differently than the watershed results, and this is more representative of user input.